### PR TITLE
Create a dashboard page with nav showing selectable accounts

### DIFF
--- a/app/dashboard/[accountId]/page.tsx
+++ b/app/dashboard/[accountId]/page.tsx
@@ -1,0 +1,12 @@
+export default function AccountHistoryPage({
+  params,
+}: {
+  params: { accountId: string };
+}) {
+  return (
+    <>
+      <h1>This page will display the transaction history for</h1>
+      <h1>Account: {params.accountId}</h1>
+    </>
+  );
+}

--- a/app/dashboard/[accountId]/page.tsx
+++ b/app/dashboard/[accountId]/page.tsx
@@ -5,8 +5,10 @@ export default function AccountHistoryPage({
 }) {
   return (
     <>
-      <h1>This page will display the transaction history for</h1>
-      <h1>Account: {params.accountId}</h1>
+      <p className="text-3xl">
+        This page will display the transaction history for Account:{" "}
+        {params.accountId}
+      </p>
     </>
   );
 }

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,12 @@
+import SideNav from "@/app/ui/dashboard/sidenav";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-screen flex-row md:flex-row md:overflow-hidden">
+      <div className="w-full flex-none md:w-64">
+        <SideNav />
+      </div>
+      <div className="flex-grow p-6 md:overflow-y-auto md:p-12">{children}</div>
+    </div>
+  );
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -2,7 +2,7 @@ import SideNav from "@/app/ui/dashboard/sidenav";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-screen flex-row md:flex-row md:overflow-hidden">
+    <div className="flex h-screen flex-col md:flex-row md:overflow-hidden">
       <div className="w-full flex-none md:w-64">
         <SideNav />
       </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function DashboardPage() {
+  return <h1>This is the dashboard page</h1>;
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,3 +1,3 @@
 export default function DashboardPage() {
-  return <h1>This is the dashboard page</h1>;
+  return <p className="text-3xl">This is the dashboard page</p>;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,33 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-}
-
-body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
-}
-
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
-}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
-
-const inter = Inter({ subsets: ["latin"] });
+import { inter } from "@/app/ui/fonts";
 
 export const metadata: Metadata = {
   title: "Flywill Trading Welcome",
@@ -16,7 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={`${inter.className} antialiased`}>{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
             of fortune.
           </p>
           <Link
-            href="/login"
+            href="/dashboard"
             className="flex items-center gap-5 self-start rounded-lg bg-blue-500 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-400 md:text-base"
           >
             <span>Log in</span> <ArrowRightIcon className="w-5 md:w-6" />

--- a/app/ui/dashboard/nav-links.tsx
+++ b/app/ui/dashboard/nav-links.tsx
@@ -12,15 +12,6 @@ const mockAccountIds = [111111, 222222, 333333, 444444, 555555, 666666];
 const links = mockAccountIds.map((id) => {
   return { name: id, href: `/dashboard/${id}`, icon: CubeIcon };
 });
-//   const links = [
-//     { name: 'Home', href: '/dashboard', icon: HomeIcon },
-//     {
-//       name: 'Invoices',
-//       href: '/dashboard/invoices',
-//       icon: CubeIcon,
-//     },
-//     { name: 'Customers', href: '/dashboard/customers', icon: CubeIcon },
-//   ];
 
 export default function NavLinks() {
   const pathname = usePathname();

--- a/app/ui/dashboard/nav-links.tsx
+++ b/app/ui/dashboard/nav-links.tsx
@@ -26,6 +26,12 @@ export default function NavLinks() {
   const pathname = usePathname();
   return (
     <>
+      {/* TODO idea: Currently, in a narrow window (mobile), the nav buttons (each representing an account)
+                       crowd into the same row. This may be fine for now, since the max number of accounts
+                       that a customer holds happens to be 6. However, there is no guarantee that the customer
+                       cannot have more accounts. It may be better to display a dropdown menu, then showing
+                       the navs for all accounts all the time.
+        */}
       {links.map((link) => {
         const LinkIcon = link.icon;
         return (

--- a/app/ui/dashboard/nav-links.tsx
+++ b/app/ui/dashboard/nav-links.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { HomeIcon, CubeIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import clsx from "clsx";
+
+// Map of links to display in the side navigation.
+// Depending on the size of the application, this would be stored in a database.
+const mockAccountIds = [111111, 222222, 333333, 444444, 555555, 666666];
+
+const links = mockAccountIds.map((id) => {
+  return { name: id, href: `/dashboard/${id}`, icon: CubeIcon };
+});
+//   const links = [
+//     { name: 'Home', href: '/dashboard', icon: HomeIcon },
+//     {
+//       name: 'Invoices',
+//       href: '/dashboard/invoices',
+//       icon: CubeIcon,
+//     },
+//     { name: 'Customers', href: '/dashboard/customers', icon: CubeIcon },
+//   ];
+
+export default function NavLinks() {
+  const pathname = usePathname();
+  return (
+    <>
+      {links.map((link) => {
+        const LinkIcon = link.icon;
+        return (
+          <Link
+            key={link.name}
+            href={link.href}
+            className={clsx(
+              "flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3",
+              {
+                "bg-sky-100 text-blue-600": pathname === link.href,
+              },
+            )}
+          >
+            <LinkIcon className="hidden md:block md:w-6" />
+            <p>{link.name}</p>
+          </Link>
+        );
+      })}
+    </>
+  );
+}

--- a/app/ui/dashboard/sidenav.tsx
+++ b/app/ui/dashboard/sidenav.tsx
@@ -6,18 +6,15 @@ import FlywheelLogo from "@/app/ui/flywheel-logo";
 export default function SideNav() {
   return (
     <div className="flex h-full flex-col px-3 py-4 md:px-2">
-      <Link
-        className="mb-2 flex h-30 items-end justify-start rounded-md bg-blue-600 p-4 md:h-40"
-        href="/"
-      >
+      <div className="mb-2 flex h-30 items-end justify-start rounded-md bg-blue-600 p-4 md:h-40">
         <div className="w-32 text-white md:w-40">
           <FlywheelLogo />
         </div>
-      </Link>
+      </div>
       <div className="flex grow flex-row justify-between space-x-2 md:flex-col md:space-x-0 md:space-y-2">
         <NavLinks />
         <div className="hidden h-auto w-full grow rounded-md bg-gray-50 md:block"></div>
-        <form>
+        <form action="/" method="GET">
           <button className="flex h-[48px] w-full grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3">
             <PowerIcon className="w-6" />
             <div className="hidden md:block">Sign Out</div>

--- a/app/ui/dashboard/sidenav.tsx
+++ b/app/ui/dashboard/sidenav.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import NavLinks from "@/app/ui/dashboard/nav-links";
+import { PowerIcon } from "@heroicons/react/24/outline";
+import FlywheelLogo from "@/app/ui/flywheel-logo";
+
+export default function SideNav() {
+  return (
+    <div className="flex h-full flex-col px-3 py-4 md:px-2">
+      <Link
+        className="mb-2 flex h-30 items-end justify-start rounded-md bg-blue-600 p-4 md:h-40"
+        href="/"
+      >
+        <div className="w-32 text-white md:w-40">
+          <FlywheelLogo />
+        </div>
+      </Link>
+      <div className="flex grow flex-row justify-between space-x-2 md:flex-col md:space-x-0 md:space-y-2">
+        <NavLinks />
+        <div className="hidden h-auto w-full grow rounded-md bg-gray-50 md:block"></div>
+        <form>
+          <button className="flex h-[48px] w-full grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3">
+            <PowerIcon className="w-6" />
+            <div className="hidden md:block">Sign Out</div>
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "flywheel-web-service",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.1.3",
+        "clsx": "^2.1.1",
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18"
@@ -105,6 +107,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.3.tgz",
+      "integrity": "sha512-fEcPfo4oN345SoqdlCDdSa4ivjaKbk0jTd+oubcgNxnNgAfzysfwWfQUr+51wigiWHQQRiZNd1Ao0M5Y3M2EGg==",
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1186,6 +1196,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "!**/*.{js,ts,jsx,tsx}": "prettier --write -u"
   },
   "dependencies": {
+    "@heroicons/react": "^2.1.3",
+    "clsx": "^2.1.1",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18"


### PR DESCRIPTION
### Summary
The dashboard page will show the user's transaction history. Keep the transaction history for each account for the same user separate by default, to follow the example of financial platforms like Vanguard.com and Etrade.com

### Main changes
1. Created a new dashboard page, with side nav that "remembers" which account is currently selected.
  - It was modeled after Learn NextJS [Chapter 4](https://nextjs.org/learn/dashboard-app/navigating-between-pages) and [Chapter 5](https://nextjs.org/learn/dashboard-app/navigating-between-pages)
  - Using `<Link>` component provided by NextJS has several benefits, like automatic [code-splitting and prefetching](https://nextjs.org/learn/dashboard-app/navigating-between-pages#automatic-code-splitting-and-prefetching) for faster user experience.
  - Like the landing page, the dashboard page is also "responsive". The content layout will change once the screen gets narrow enough.
2. Enabled navigating from the landing page to the dashboard page via the Login button, then back to the landing page via Sign out button.
  - Adding a proper authentication will be out of scope for now.
### Validation

Navigating from the landing page to the dashboard, then toggling between accounts, and finally signing out:

https://github.com/chohanbin/flywheel-web-service/assets/5660356/ce958b34-bfa0-43f3-9b29-1f8c34643f9f


Once the screen gets narrow enough, the content layout changes:

https://github.com/chohanbin/flywheel-web-service/assets/5660356/41ae0296-4b61-4a8d-bcfb-a4f28a3e95f1

